### PR TITLE
Added commands

### DIFF
--- a/Qtutorial.tex
+++ b/Qtutorial.tex
@@ -174,7 +174,19 @@ wires at the beginning by inserting the \verb=&= character at the start of each 
      & \gate{U^\dag} & \qw
 } \]\end{verbatim}}
 
-The only difference between these two codes is that the correct code has an ampersand (\verb=&=) at the start of each new line.
+The only difference between these two codes is that the correct code has an ampersand (\verb=&=) at the start of each new line.\\
+
+To indicate the end of a circuit simply use the \verb=\qwa= command as the last wire.
+
+\[ \Qcircuit @C=1em @R=.7em {
+     & \gate{U} & \qwa \\
+     & \gate{U^\dag} & \qwa
+} \]
+
+{\small \begin{verbatim}\[ \Qcircuit @C=1em @R=.7em {
+     & \gate{U} & \qwa \\
+     & \gate{U^\dag} & \qwa
+} \]\end{verbatim}}
 
 \subsection{CNOT and other controlled single qubit gates \label{S:CNOT}}
 
@@ -264,6 +276,29 @@ typeset with
  \lstick{\ket{1}} & \ctrl{-1} & \rstick{\ket{1}} \qw
 }\end{verbatim}}
 
+There are a few options for labelling multi-qubit input states, as well.
+
+
+\[ \Qcircuit @C=1em @R=1.6em {
+    \lstick{} & \qw & \qw \\
+    \lstick{} & \qw & \qw \inputgroup{1}{2}{.75em}{\ket{0^k}}\\
+    \lstick{} & \qw & \qw \\
+    \lstick{} & \qw & \qw \inputgroupv{3}{4}{.8em}{.8em}{\ket{\psi}}\\
+    \lstick{A} & \qw & \qw \\
+    \lstick{B} & \qw & \qw \inputgrouph{5}{6}{.75em}{\ket{\psi}}{2.2em}
+  }\]
+typeset with
+{\small \begin{verbatim}\Qcircuit @C=1em @R=1.6em {
+    \lstick{} & \qw & \qw \\
+    \lstick{} & \qw & \qw 
+      \inputgroup{1}{2}{.75em}{\ket{0^k}}\\
+    \lstick{} & \qw & \qw \\
+    \lstick{} & \qw & \qw
+      \inputgroupv{3}{4}{.8em}{.8em}{\ket{\psi}}\\
+    \lstick{A} & \qw & \qw \\
+    \lstick{B} & \qw & \qw 
+      \inputgrouph{5}{6}{.75em}{\ket{\psi}}{2.2em}
+  }\end{verbatim}}
 
 \section{More Complicated Circuits: Multiple Qubit Gates and Beyond}
 
@@ -315,6 +350,20 @@ with the label for the gate is needed.  Strictly speaking, the name of the gate 
 Note that controls to multiple qubit gates work the same as for single
 qubit gates, using \verb=\ctrl= and \verb=\qwx=.
 
+To indicate a gate applied to multiple qubits which are non-adjacent, simply use the \verb=\sgate= command like so
+
+{\small \begin{verbatim}\Qcircuit @C=1em @R=.7em {
+     & \multigate{1}{\mathcal{F}} & \qw \\
+     & \ghost{\mathcal{F}} & \qw \\
+     & \qw & \qw 
+}\end{verbatim}}
+\noindent yields
+\[ \Qcircuit @C=1em @R=.7em {
+     & \multigate{1}{\mathcal{F}} & \sgate{\mathcal{G}}{2} & \qw \\
+     & \ghost{\mathcal{F}} & \qw & \qw\\
+     & \qw & \gate{\mathcal{G}} & \qw \\
+}\]
+
 \subsection{Measurements and classical bits}
 
 Measurement gates are typeset just like ordinary gates, but they typically have some sort of decoration to indicate that measurement has occurred.  At present, Q-circuit supports the following single qubit measurement gates.
@@ -328,7 +377,9 @@ Measurement gates are typeset just like ordinary gates, but they typically have 
         \Qcircuit @C=1em @R=.7em {& \measuretab{M_{ijk}}} \hspace{.5em}
             & \verb=\measuretab= & \verb=\measuretab{M_{ijk}}=\\
         \Qcircuit @C=1em @R=.7em {& \measureD{\chi}}
-            & \verb=\measureD= & \verb=\measureD{\chi}=
+            & \verb=\measureD= & \verb=\measureD{\chi}=\\\\
+        \Qcircuit @C=1em @R=1.5em{ &\meterB{\ket{\xi_\pm}}}
+            & \verb=\meterB= & \verb=\meterB{\ket{\xi_\pm}}=
     \end{tabular}
 \end{center}}
 
@@ -343,6 +394,15 @@ Here is an example using measurement gates and classical wires and the correspon
      & \qw & \measure{\mbox{Codebit}} \cwx[1] \\
      & \qw & \gate{\chi} & \meter &
         \rstick{\cdots} \cw
+}\end{verbatim}}
+
+If you are using a special basis for your measurements the \verb=\meterB= command allows you to indicate the basis.
+\[\Qcircuit @C=1em @R=1.5em {
+    \lstick{\ket{\psi}} & \meterB{\ket{\xi_\pm}} & \cw
+}\]
+{\small \begin{verbatim}\Qcircuit @C=1em @R=1.5em {
+    \lstick{\ket{\psi}}  &\ctrl{1} & \qw & \qwa \\
+    \lstick{\ket{0}}  & \targ & \meterB{\ket{\xi_\pm}} & \cw
 }\end{verbatim}}
 
 Q-circuit also includes the commands \verb=\multimeasure= and \verb=\multimeasureD= for typesetting measurements on multiple qubits.  The syntax for these commands exactly parallels that of the \verb=\multigate= command (see \S\ref{S:multigate}).  An example is shown below.
@@ -377,6 +437,22 @@ Here is a circuit that shows how to construct swap, decorate wires, and use \ver
      & {/} \qw & \gate{H^{\otimes n}} & \qw
 }\end{verbatim}}
 
+To indicate a generalized circuit with $n$ iterations of something, you could use the \verb=\cds= command.
+\[\Qcircuit @C=1em @R=.7em {
+     & \targ & \targ & \cds{4}{\cdots} & \targ & \qw\\
+     & \ctrl{-1} & \qw &\qw & \qw & \qw \\
+     & \qw & \ctrl{-2} & \qw & \qw & \qw \\
+     & & & & & \\
+     & \qw & \qw & \qw & \ctrl{-4} & \qw \\
+}\]
+{\small \begin{verbatim}\Qcircuit @C=1em @R=.3em {
+     & \targ & \targ & \cds{4}{\cdots} & \targ & \qw\\
+     & \ctrl{-1} & \qw &\qw & \qw & \qw \\
+     & \qw & \ctrl{-2} & \qw & \qw & \qw \\
+     & & & & & \\
+     & \qw & \qw & \qw & \ctrl{-4} & \qw \\
+}\end{verbatim}}
+
 \subsection{How to control anything}
 
 Controlled-Z gates, wires with bends, and gates that control-on-zero can all be made using the extended family of control commands.  The complete family of control commands is \verb=\ctrl=, \verb=\crtlo=, \verb=\control=, and \verb=\controlo=.
@@ -389,8 +465,8 @@ Here is an example circuit using various controls.
 \[ \Qcircuit @C=1em @R=.7em {
     & \ctrl{2} & \ctrlo{1} & \ctrl{1} & \qw & \multigate{1}{U} & \qw \\
     & \qw & \targ & \ctrlo{2} \qw & \ctrl{1} & \ghost{U} & \qw\\
-    & \control \qw & \ctrl{1} & \qw & \meter & \controlo \cw \cwx &\\
-    & \qw & \control \qw & \gate{H} & \meter & \control \cw \cwx
+    & \control \qw & \ctrl{1} & \qw & \meter & \cctrlo{-1} &\\
+    & \qw & \control \qw & \gate{H} & \meter & \cctrl{-1}
 }\]
 
 {\small \begin{verbatim}\Qcircuit @C=1em @R=.7em {
@@ -399,9 +475,9 @@ Here is an example circuit using various controls.
     & \qw & \targ & \ctrlo{2} \qw 
         & \ctrl{1} & \ghost{U} & \qw \\
     & \control \qw & \ctrl{1} & \qw 
-        & \meter & \controlo \cw \cwx \\
+        & \meter & \cctrlo{-1} \\
     & \qw & \control \qw & \gate{H} 
-        & \meter & \control \cw \cwx
+        & \meter & \cctrl{-1}
 }\end{verbatim}}
 
 Note that we, the authors, have used a pair of controls connected by a wire to denote the controlled-Z gate.  This isn't standard notation, but we feel it is a logically consistent and concise notation, and it illustrates nicely the symmetry of the controlled-Z gate.  We hope to encourage the readers to adopt this notation in their own QCDs.

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -63,14 +63,26 @@
 \newcommand{\qwx}[1][-1]{\ar @{-} [#1,0]}
     % Defines a wire that connects vertically.  By default it connects to the object above the current object.
     % WARNING: Wire commands must appear after the gate in any given entry.
+\newcommand{\qwa}[1][-1]{\ar @{<-} [0,#1]}
+    % Defines a wire that connects horizontally with an arrow.  By default it makes an end wire with an arrow indicating the end of the circuit.
+    % WARNING: Wire commands must appear after the gate in any given entry.
 \newcommand{\cw}[1][-1]{\ar @{=} [0,#1]}
     % Defines a classical wire that connects horizontally.  By default it connects to the object on the left of the current object.
     % WARNING: Wire commands must appear after the gate in any given entry.
 \newcommand{\cwx}[1][-1]{\ar @{=} [#1,0]}
     % Defines a classical wire that connects vertically.  By default it connects to the object above the current object.
     % WARNING: Wire commands must appear after the gate in any given entry.
+\newcommand{\cwa}[1][-1]{\ar @{<=} [0,#1]}
+    % Defines a classical wire that connects horizontally with an arrow.  By default it makes an end wire with an arrow indicating the end of the circuit.
+    % WARNING: Wire commands must appear after the gate in any given entry.
+\newcommand{\cds}[2]{*+<1em,.9em>{\hphantom{#2}} \POS [0,0].[#1,0]="e",!C *{#2};"e"+ R \qw}
+    % Allows the insertion of text without a box and exands circuit around this text.
+    % This is useful for such things as ... to indicate a generalized circuit.
 \newcommand{\gate}[1]{*+<.6em>{#1} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \qw}
     % Boxes the argument, making a gate.
+\newcommand{\sgate}[2]{\gate{#1}  \qwx[#2]}
+    % Creates a gate and a qwx wire going #2 spots below, for a gate split over
+    % non-adjacent rows
 \newcommand{\meter}{*=<1.8em,1.4em>{\xy ="j","j"-<.778em,.322em>;{"j"+<.778em,-.322em> \ellipse ur,_{}},"j"-<0em,.4em>;p+<.5em,.9em> **\dir{-},"j"+<2.2em,2.2em>*{},"j"-<2.2em,2.2em>*{} \endxy} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \qw}
     % Inserts a measurement meter.
     % In case you're wondering, the constants .778em and .322em specify
@@ -78,6 +90,17 @@
     % The points added at + and - <2.2em,2.2em> are there to strech the
     % canvas, ensuring that the size is unaffected by erratic spacing issues
     % with the arc.
+\newcommand{\metersymb}{\xy ="j","j"-<.778em,.322em>;{"j"+<.778em,-.322em> \ellipse ur,_{}},"j"-<0em,.4em>;p+<.5em,.9em> **\dir{-},"j"+<2.2em,2.2em>*{},"j"-<2.2em,2.2em>*{} \endxy}
+    % A longer meter
+\newcommand{\meterB}[1]{*=<1.8em,2.6em>{\xy 0;<0em,-.8em>:
+0*{\begingroup
+\everymath{\scriptstyle}
+\tiny #1 \endgroup},<0em,.7em>*{\xy ="j","j"-<.778em,-.322em>;{"j"+<.778em,.322em> \ellipse ur,_{}},"j"-<0em,-.2em>;p+<.5em,.9em> **\dir{-},"j"+<2.2em,2.2em>*{},"j"-<2.2em,2.2em>*{} \endxy} 
+\endxy} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \qw}
+    % A meter that allows for a measurememnet operator to be added below
+\newcommand{\smeterB}[2]{\meterB{#1} \qwx[#2] \qw}
+    % A split meter that allows for a measurement operator to be split over non-
+    % adjacent rows
 \newcommand{\measure}[1]{*+[F-:<.9em>]{#1} \qw}
     % Inserts a measurement bubble with user defined text.
 \newcommand{\measuretab}[1]{*{\xy*+<.6em>{#1}="e";"e"+UL;"e"+UR **\dir{-};"e"+DR **\dir{-};"e"+DL **\dir{-};"e"+LC-<.5em,0em> **\dir{-};"e"+UL **\dir{-} \endxy} \qw}
@@ -100,6 +123,8 @@
     % Inserts a control and connects it to the object #1 wires below.
 \newcommand{\ctrlo}[1]{\controlo \qwx[#1] \qw}
     % Inserts a control-on-0 and connects it to the object #1 wires below.
+\newcommand{\cctrl}[1]{\control \cwx[#1] \cw}
+    % Inserts a classical control and connects it to the object #1 wires below.     
 \newcommand{\targ}{*+<.02em,.02em>{\xy ="i","i"-<.39em,0em>;"i"+<.39em,0em> **\dir{-}, "i"-<0em,.39em>;"i"+<0em,.39em> **\dir{-},"i"*\xycircle<.4em>{} \endxy} \qw}
     % Inserts a CNOT target.
 \newcommand{\qswap}{*=<0em>{\times} \qw}
@@ -125,7 +150,12 @@
     % dotted boxes respectively, and the last eight options yield bottom, top, left, and right braces of the curly or normal variety.  See the Xy-pic reference manual for more options.
     % \gategroup can appear at the end of any gate entry, but it's good form to pick either the last entry or one of the corner gates.
     % BUG: \gategroup uses the four corner gates to determine the size of the bounding box.  Other gates may stick out of that box.  See \prop.
-
+\newcommand{\inputgroup}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1"!C*+<#3>\frm{\{}, \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1.7em,#4>=<0em>{#5}}
+    % Constructs an input group with label #5 and a grouping { from rows #1 to #2 with #3 and #4 controlling the spacing
+\newcommand{\inputgroupb}[4]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1em,#3>=<0em>{#4}}
+    % Constructs an input group with label #4 from rows #1 to #2 with #3 controlling the spacing
+\newcommand{\inputgroupc}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<#5,#3>=<0em>{#4}}
+    % Constructs an input group with label #4 and a grouping /vdots from rows #1 to #2 with #3 and #5 controlling the spacing
 \newcommand{\rstick}[1]{*!L!<-.5em,0em>=<0em>{#1}}
     % Centers the left side of #1 in the cell.  Intended for lining up wire labels.  Note that non-gates have default size zero.
 \newcommand{\lstick}[1]{*!R!<.5em,0em>=<0em>{#1}}

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -23,16 +23,16 @@
 \RequirePackage{xy}
 
 \DeclareOption{braket}{
-	\newcommand{\bra}[1]{\ensuremath{\left\langle{#1}\right\vert}}
-	\newcommand{\ket}[1]{\ensuremath{\left\vert{#1}\right\rangle}}
-	}
+    \newcommand{\bra}[1]{\ensuremath{\left\langle{#1}\right\vert}}
+    \newcommand{\ket}[1]{\ensuremath{\left\vert{#1}\right\rangle}}
+    }
 
 \DeclareOption{qm}{
-	\newcommand{\ip}[2]{\ensuremath{\left\langle{#1}\right\vert{#2}\rangle}}
-	\newcommand{\melem}[3]{\ensuremath{\left\langle{#1}\right\vert{#2}\vert{#3}\rangle}}
-	\newcommand{\expval}[1]{\ensuremath{\left\langle #1 \right\rangle}}
-	\newcommand{\op}[2]{\ensuremath{\vert{#1}\rangle\langle{#2}\vert}}
-	}
+    \newcommand{\ip}[2]{\ensuremath{\left\langle{#1}\right\vert{#2}\rangle}}
+    \newcommand{\melem}[3]{\ensuremath{\left\langle{#1}\right\vert{#2}\vert{#3}\rangle}}
+    \newcommand{\expval}[1]{\ensuremath{\left\langle #1 \right\rangle}}
+    \newcommand{\op}[2]{\ensuremath{\vert{#1}\rangle\langle{#2}\vert}}
+    }
 
 \ProcessOptions\relax
 
@@ -124,7 +124,9 @@
 \newcommand{\ctrlo}[1]{\controlo \qwx[#1] \qw}
     % Inserts a control-on-0 and connects it to the object #1 wires below.
 \newcommand{\cctrl}[1]{\control \cwx[#1] \cw}
-    % Inserts a classical control and connects it to the object #1 wires below.     
+    % Inserts a classical control and connects it to the object #1 wires below. 
+\newcommand{\cctrlo}[1]{\controlo \cwx[#1] \cw}
+    % Inserts a classical control-on-0 and connects it to the object #1 wires below.    
 \newcommand{\targ}{*+<.02em,.02em>{\xy ="i","i"-<.39em,0em>;"i"+<.39em,0em> **\dir{-}, "i"-<0em,.39em>;"i"+<0em,.39em> **\dir{-},"i"*\xycircle<.4em>{} \endxy} \qw}
     % Inserts a CNOT target.
 \newcommand{\qswap}{*=<0em>{\times} \qw}
@@ -150,11 +152,11 @@
     % dotted boxes respectively, and the last eight options yield bottom, top, left, and right braces of the curly or normal variety.  See the Xy-pic reference manual for more options.
     % \gategroup can appear at the end of any gate entry, but it's good form to pick either the last entry or one of the corner gates.
     % BUG: \gategroup uses the four corner gates to determine the size of the bounding box.  Other gates may stick out of that box.  See \prop.
-\newcommand{\inputgroup}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1"!C*+<#3>\frm{\{}, \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1.7em,#4>=<0em>{#5}}
+\newcommand{\inputgroupv}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1"!C*+<#3>\frm{\{}, \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1.7em,#4>=<0em>{#5}}
     % Constructs an input group with label #5 and a grouping { from rows #1 to #2 with #3 and #4 controlling the spacing
-\newcommand{\inputgroupb}[4]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1em,#3>=<0em>{#4}}
+\newcommand{\inputgroup}[4]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<1em,#3>=<0em>{#4}}
     % Constructs an input group with label #4 from rows #1 to #2 with #3 controlling the spacing
-\newcommand{\inputgroupc}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<#5,#3>=<0em>{#4}}
+\newcommand{\inputgrouph}[5]{\POS"#1,1"."#2,1"."#1,1"."#2,1", \POS"#1,1"."#2,1"."#1,1"."#2,1"*!C!<#5,#3>=<0em>{#4}}
     % Constructs an input group with label #4 and a grouping /vdots from rows #1 to #2 with #3 and #5 controlling the spacing
 \newcommand{\rstick}[1]{*!L!<-.5em,0em>=<0em>{#1}}
     % Centers the left side of #1 in the cell.  Intended for lining up wire labels.  Note that non-gates have default size zero.


### PR DESCRIPTION
\qwa and \cwa for arrow wires

\cds for inserting … indicating general circuit

\sgate for creating gates split over non-adjacent rows

\metersymb is a new meter aesthetic

\meterB allows for a measurement operator to be added

\smeterB allows for split meters over non-adjacent rows

\cctrl allows for classical control

\inputgroups for allowing multiple rows to represent one state